### PR TITLE
Redirect landing page to new document page

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+try.octo.app

--- a/src/router.js
+++ b/src/router.js
@@ -22,6 +22,10 @@ const router = new Router({
       children: [
         // editor views
         {
+          path: '',
+          redirect: { name: 'dashboard' },
+        },
+        {
           path: 'documents/new',
           name: 'dashboard',
           component: Editor,


### PR DESCRIPTION
- closes #2 

### Summary

The landing page is just a blank page right now, so just redirect it.