### PR TITLE
Add cmd+s shortcut

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -231,6 +231,11 @@ export default {
       this.toggleMenu();
     });
 
+    Mousetrap.bindGlobal('mod+s', (e, keys) => {
+      // the editor autosaves, so there is no need to do anything but prevent the browser prompt
+      e.preventDefault();
+    });
+
     Mousetrap.bindGlobal('mod+shift+f', (e, keys) => {
       e.preventDefault();
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -226,10 +226,14 @@ export default {
     });
 
     Mousetrap.bindGlobal('mod+k', (e, keys) => {
+      e.preventDefault();
+
       this.toggleMenu();
     });
 
     Mousetrap.bindGlobal('mod+shift+f', (e, keys) => {
+      e.preventDefault();
+
       this.hideMenu();
       this.$router.push({ name: 'documents' });
     });


### PR DESCRIPTION
- resolves #12 
- resolves #23 

### Summary

The editor autosaves, so we really just need to prevent the default browser behavior on `cmd+s`.