### PR TITLE
Load and filter out documents that cannot be decrypted

### DIFF
--- a/src/components/DocumentList.vue
+++ b/src/components/DocumentList.vue
@@ -87,7 +87,7 @@ export default {
       } else if (this.untagged) {
         return this.$store.getters.untagged;
       } else {
-        return this.$store.state.documents.all;
+        return this.$store.getters.decrypted;
       }
     },
     filterMessage() {

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -72,7 +72,7 @@ export default {
       return this.mounted ? this.$refs.editable.codeblocks : [];
     },
     document() {
-      return this.$store.state.documents.all.find(doc => doc.clientId === this.$route.params.documentId) || this.placeholder;
+      return this.$store.getters.decrypted.find(doc => doc.clientId === this.$route.params.documentId) || this.placeholder;
     },
     hasCodeblocks() {
       return this.codeblocks.length > 0;

--- a/src/store/plugins/caching/documents.js
+++ b/src/store/plugins/caching/documents.js
@@ -35,22 +35,18 @@ export default (store) => {
 
         if (found) {
           debouncer.debounce(found.clientId, () => {
-            if (state.settings.crypto.enabled || found.encrypted) {
-              if (state.settings.crypto.publicKey) {
-                encrypt(found.text, state.settings.crypto.publicKey).then((encrypted) => {
-                  const secureDoc = Object.assign({}, found, {
-                    dataKey: encrypted.encryptedKey,
-                    encrypted: true,
-                    iv: encrypted.iv,
-                    tags: [], // tags will be restored upon decryption
-                    text: encrypted.cipher,
-                  });
-
-                  cache.setItem(found.clientId, secureDoc);
+            if (state.settings.crypto.enabled && state.settings.crypto.publicKey && !found.encrypted) {
+              encrypt(found.text, state.settings.crypto.publicKey).then((encrypted) => {
+                const secureDoc = Object.assign({}, found, {
+                  dataKey: encrypted.encryptedKey,
+                  encrypted: true,
+                  iv: encrypted.iv,
+                  tags: [], // tags will be restored upon decryption
+                  text: encrypted.cipher,
                 });
-              } else {
-                console.log('publicKey missing - cannot store document');
-              }
+
+                cache.setItem(found.clientId, secureDoc);
+              });
             } else {
               cache.setItem(found.clientId, found);
             }


### PR DESCRIPTION
Instead of excluding encrypted documents that cannot be decrypted (from a missing or incorrect key), we will instead load them as normal and just exclude them from the current UI. Eventually, I would love to introduce a "vault" list to allow users to see that they have encrypted documents (like if they haven't supplied keys yet on a new client) and even decrypt documents with alternative keys.