### PR TITLE
Add basic export feature to settings menu

### DIFF
--- a/src/components/Exporter.vue
+++ b/src/components/Exporter.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="container-lg">
+    <div class="editor">
+      <MarkdownEditor ref="editable" class="editable" :value="value" />
+    </div>
+  </div>
+</template>
+
+<script>
+import MarkdownEditor from '@/components/MarkdownEditor';
+
+export default {
+  name: 'Exporter',
+  components: {
+    MarkdownEditor,
+  },
+  computed: {
+    value() {
+      return JSON.stringify(this.$store.state.documents.all, null, 2);
+    },
+  },
+  methods: {
+    focus() {
+      this.$refs.editable.focus();
+    },
+  },
+  mounted() {
+    this.focus();
+  },
+};
+</script>
+
+<style scoped>
+  /* Duped from TheEditor for now */
+  .editor {
+    background: url('~@/assets/octopus-transparent.svg') center center no-repeat;
+    background-size: 50% 50%;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    margin: auto;
+    min-height: 30rem;
+  }
+
+  .editor .editable {
+    outline: none;
+    white-space: pre-wrap;
+  }
+</style>

--- a/src/components/TheSettings.vue
+++ b/src/components/TheSettings.vue
@@ -43,6 +43,16 @@
           <button @click="generateKeys" class="btn btn-secondary">Generate Keys</button>
         </div>
       </section>
+      <section>
+        <h4 class="font-weight-normal mt-3 mt-md-5">Export Documents</h4>
+        <hr>
+        <div class="form-group">
+          <label>Bundle all documents as JSON. Documents will be decrypted if the necessary keys are available.</label>
+        </div>
+        <div class="form-group">
+          <button @click="exportDocs" class="btn btn-secondary">Export Documents</button>
+        </div>
+      </section>
     </div>
   </div>
 </template>
@@ -122,6 +132,9 @@ export default {
 
       this.privateKey = privateKey;
       this.publicKey = publicKey;
+    },
+    async exportDocs() {
+      this.$router.push({ name: 'export' });
     },
   },
 };

--- a/src/router.js
+++ b/src/router.js
@@ -7,6 +7,7 @@ import Dashboard from './views/Dashboard.vue';
 // components
 import Context from './components/Context.vue';
 import DocumentList from './components/DocumentList.vue';
+import Exporter from './components/Exporter.vue';
 import TheEditor from './components/TheEditor.vue';
 import TheSettings from './components/TheSettings.vue';
 import TagList from './components/TagList.vue';
@@ -36,6 +37,11 @@ const router = new Router({
           name: 'dashboard',
           component: TheEditor,
           props: true,
+        },
+        {
+          path: 'documents/export',
+          name: 'export',
+          component: Exporter,
         },
         // document filters
         {


### PR DESCRIPTION
- resolves #42 

### Summary

In the settings menu, there is now an "Export Documents" button. This will convert all documents to JSON and decrypt them if possible. The JSON will then be available to copy/paste from the editor. Eventually, this should automatically prompt for a download, but this is a good first step.