### PR TITLE
Add support for tags with dashes

### DIFF
--- a/src/common/parsers.js
+++ b/src/common/parsers.js
@@ -1,5 +1,5 @@
 const codeRegex = /```([^\n\s]*)(?:\s([\w-]+\.[\w]+))?\n(.*?)```/gs;
-const tagsRegex = /````.*?````|```.*?```|``.*?``|`.*?`|\w+:\/?\/?\S*|#(\w+)/gs;
+const tagsRegex = /````.*?````|```.*?```|``.*?``|`.*?`|\w+:\/?\/?\S*|#([\w-]+)/gs;
 
 export const parse = (regex, text) => {
   let matches = [];


### PR DESCRIPTION
Fixes #48 

Previously, tags with a `-` character would discard the dash and
anything afterwards. For example `#my-tag` would become `#my`.

The reason for this is the regex `\w` does not include `-`. Update the
regex to include `-` explicitly allows the use of `-` to create
"dasherized" tags.