### PR TITLE
Detect and display mod key based on user agent

### DIFF
--- a/src/components/CommandK.vue
+++ b/src/components/CommandK.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="d-none d-md-flex align-items-center">
-    <Key :class="{ active: active }">cmd</Key>
+    <Key :class="{ active: active }">{{this.$store.state.mod_key}}</Key>
     <Key :class="{ active: active }" class="ml-1">k</Key>
   </div>
 </template>

--- a/src/components/ModK.vue
+++ b/src/components/ModK.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="d-none d-md-flex align-items-center">
-    <Key :class="{ active: active }">{{this.$store.state.mod_key}}</Key>
+    <Key :class="{ active: active }">{{this.$store.state.modKey}}</Key>
     <Key :class="{ active: active }" class="ml-1">k</Key>
   </div>
 </template>
@@ -9,7 +9,7 @@
 import Key from '@/components/Key';
 
 export default {
-  name: 'CommandK',
+  name: 'ModK',
   components: {
     Key,
   },

--- a/src/components/ModKKey.vue
+++ b/src/components/ModKKey.vue
@@ -8,7 +8,7 @@
 import Key from '@/components/Key';
 
 export default {
-  name: 'CommandKKey',
+  name: 'ModKKey',
   components: {
     Key,
   },

--- a/src/components/TheSidebar.vue
+++ b/src/components/TheSidebar.vue
@@ -12,7 +12,7 @@
             <router-link class="btn btn-secondary d-flex align-items-center justify-content-between w-100" :to="{ name: 'documents' }">
               <SearchLabel>search</SearchLabel>
               <span class="d-none d-md-flex">
-                <Key :toggleable="false">{{this.$store.state.mod_key}}</Key>
+                <Key :toggleable="false">{{this.$store.state.modKey}}</Key>
                 <Key class="ml-1" :toggleable="false">shift</Key>
                 <Key class="ml-1" :toggleable="false">f</Key>
               </span>
@@ -21,7 +21,7 @@
           <h6 class="dropdown-header mx-0 mt-3 px-3 d-flex justify-content-between">
             <span>actions</span>
             <span class="keybinding d-flex">
-              <CommandK/>
+              <ModK/>
             </span>
           </h6>
           <div class="item-divider"></div>
@@ -34,7 +34,7 @@
             <span class="action d-flex flex-grow-1 align-items-center justify-content-between">
               <span class="action">add document</span>
               <span class="keybinding d-flex">
-                <CommandKKey>n</CommandKKey>
+                <ModKKey>n</ModKKey>
               </span>
             </span>
           </router-link>
@@ -46,7 +46,7 @@
             </svg>
             <span class="action d-flex flex-grow-1 align-items-center justify-content-between">
               <span class="action">change context</span>
-              <CommandKKey>c</CommandKKey>
+              <ModKKey>c</ModKKey>
             </span>
           </router-link>
           <router-link class="item px-3 py-2 py-md-1" :to="{ name: 'settings' }">
@@ -56,7 +56,7 @@
             </svg>
             <span class="action d-flex flex-grow-1 align-items-center justify-content-between">
               <span>editor settings</span>
-              <CommandKKey>e</CommandKKey>
+              <ModKKey>e</ModKKey>
             </span>
           </router-link>
           <a class="item px-3 py-2 py-md-1" target="_blank" href="https://github.com/voraciousdev/octo/issues">
@@ -65,13 +65,13 @@
             </svg>
             <span class="action d-flex flex-grow-1 align-items-center justify-content-between">
               <span>report issue</span>
-              <CommandKKey>i</CommandKKey>
+              <ModKKey>i</ModKKey>
             </span>
           </a>
           <h6 class="dropdown-header mx-0 mt-3 px-3 d-flex justify-content-between">
             <span>quick filters</span>
             <span class="keybinding d-flex">
-              <CommandK/>
+              <ModK/>
             </span>
           </h6>
           <div class="item-divider"></div>
@@ -79,7 +79,7 @@
             <TaskLabel class="flex-grow-1">
               <span class="d-flex align-items-center justify-content-between">
                 <span>actionable</span>
-                <CommandKKey>a</CommandKKey>
+                <ModKKey>a</ModKKey>
               </span>
             </TaskLabel>
           </router-link>
@@ -87,7 +87,7 @@
             <TimelyLabel class="flex-grow-1">
               <span class="d-flex align-items-center justify-content-between">
                 <span>recent</span>
-                <CommandKKey>r</CommandKKey>
+                <ModKKey>r</ModKKey>
               </span>
             </TimelyLabel>
           </router-link>
@@ -95,7 +95,7 @@
             <DocumentLabel class="flex-grow-1">
               <span class="d-flex align-items-center justify-content-between">
                 <span>untagged</span>
-                <CommandKKey>u</CommandKKey>
+                <ModKKey>u</ModKKey>
               </span>
             </DocumentLabel>
           </router-link>
@@ -103,7 +103,7 @@
             <DiscardLabel class="flex-grow-1">
               <span class="d-flex align-items-center justify-content-between">
                 <span>discarded</span>
-                <CommandKKey>d</CommandKKey>
+                <ModKKey>d</ModKKey>
               </span>
             </DiscardLabel>
           </router-link>
@@ -121,11 +121,11 @@
 </template>
 
 <script>
-import CommandK from '@/components/CommandK';
-import CommandKKey from '@/components/CommandKKey';
 import DiscardLabel from '@/components/labels/Discard';
 import DocumentLabel from '@/components/labels/Document';
 import Key from '@/components/Key';
+import ModK from '@/components/ModK';
+import ModKKey from '@/components/ModKKey';
 import SearchLabel from '@/components/labels/Search';
 import Tag from '@/components/Tag';
 import TaskLabel from '@/components/labels/Task';
@@ -135,11 +135,11 @@ import TimelyLabel from '@/components/labels/Timely';
 export default {
   name: 'dashboard',
   components: {
-    CommandK,
-    CommandKKey,
     DiscardLabel,
     DocumentLabel,
     Key,
+    ModK,
+    ModKKey,
     SearchLabel,
     Tag,
     TaskLabel,

--- a/src/components/TheSidebar.vue
+++ b/src/components/TheSidebar.vue
@@ -12,7 +12,7 @@
             <router-link class="btn btn-secondary d-flex align-items-center justify-content-between w-100" :to="{ name: 'documents' }">
               <SearchLabel>search</SearchLabel>
               <span class="d-none d-md-flex">
-                <Key :toggleable="false">cmd</Key>
+                <Key :toggleable="false">{{this.$store.state.mod_key}}</Key>
                 <Key class="ml-1" :toggleable="false">shift</Key>
                 <Key class="ml-1" :toggleable="false">f</Key>
               </span>

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@ import Doc from '@/models/doc';
 
 import {
   ADD_DOCUMENT,
+  SET_MOD_KEY,
   SET_OFFLINE,
   SET_ONLINE,
 } from '@/store/actions';
@@ -27,7 +28,6 @@ Vue.use(VueMq, {
     xl: Infinity,
   },
 });
-
 
 new Vue({
   router,
@@ -44,6 +44,10 @@ new Vue({
 
     if (!navigator.onLine) {
       await this.$store.dispatch(SET_OFFLINE);
+    }
+
+    if (navigator.userAgent.indexOf("Macintosh") > 0) {
+      this.$store.dispatch(SET_MOD_KEY, 'cmd');
     }
 
     if (localStorage.getItem('octo/welcome/v1') === null) {

--- a/src/main.js
+++ b/src/main.js
@@ -46,7 +46,7 @@ new Vue({
       await this.$store.dispatch(SET_OFFLINE);
     }
 
-    if (navigator.userAgent.indexOf("Macintosh") > 0) {
+    if (/Mac|iPod|iPhone|iPad/.test(navigator.platform)) {
       this.$store.dispatch(SET_MOD_KEY, 'cmd');
     }
 

--- a/src/store.js
+++ b/src/store.js
@@ -25,6 +25,7 @@ import {
   HIDE_MENU,
   SET_CONTEXT_TAGS,
   SET_EDITOR,
+  SET_MOD_KEY,
   SET_OFFLINE,
   SET_ONLINE,
   SHOW_MENU,
@@ -34,6 +35,7 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
+    mod_key: 'ctrl',
     context: {
       active: false,
       editing: false,
@@ -95,6 +97,9 @@ export default new Vuex.Store({
     [SET_ONLINE] (state) {
       state.online = true;
     },
+    [SET_MOD_KEY] (state, payload) {
+      state.mod_key = payload;
+    },
     [SHOW_MENU] (state) {
       state.menu.show = true;
     },
@@ -135,6 +140,9 @@ export default new Vuex.Store({
     },
     async [SET_EDITOR] (context, payload) {
       context.commit(SET_EDITOR, payload);
+    },
+    async [SET_MOD_KEY] (context, payload) {
+      context.commit(SET_MOD_KEY, payload);
     },
     async [SET_OFFLINE] (context) {
       context.commit(SET_OFFLINE);

--- a/src/store.js
+++ b/src/store.js
@@ -35,7 +35,7 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
-    mod_key: 'ctrl',
+    modKey: 'ctrl',
     context: {
       active: false,
       editing: false,
@@ -98,7 +98,7 @@ export default new Vuex.Store({
       state.online = true;
     },
     [SET_MOD_KEY] (state, payload) {
-      state.mod_key = payload;
+      state.modKey = payload;
     },
     [SHOW_MENU] (state) {
       state.menu.show = true;

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -12,6 +12,7 @@ export const LOAD_DOCUMENTS = 'LOAD_DOCUMENTS';
 export const RESTORE_DOCUMENT = 'RESTORE_DOCUMENT';
 export const SET_CONTEXT_TAGS = 'SET_CONTEXT_TAGS';
 export const SET_EDITOR = 'SET_EDITOR';
+export const SET_MOD_KEY = 'SET_MOD_KEY';
 export const SET_OFFLINE = 'SET_OFFLINE';
 export const SET_ONLINE = 'SET_ONLINE';
 export const SHOW_MENU = 'SHOW_MENU';
@@ -32,6 +33,7 @@ export default {
   RESTORE_DOCUMENT,
   SET_CONTEXT_TAGS,
   SET_EDITOR,
+  SET_MOD_KEY,
   SET_OFFLINE,
   SET_ONLINE,
   SHOW_MENU,


### PR DESCRIPTION
Resolves #20 

On mac, the modifier key is `cmd` while other systems will most likely use
`ctrl`. The underlying keybinding plugin handles this situation already
but Octo did not adjust the visual hints in the UI for non mac users.

To solve this, we look for `Macintosh` in the user agent. If present,
display `cmd` as the mod key in keybinding hints. Otherwise, we assume
`ctrl`.

This is calculated when initializing the app. We set this state in the
store.