### PR TITLE
Upgrade CodeMirror (for wast support) and use package version for CDN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3626,9 +3626,9 @@
       "dev": true
     },
     "codemirror": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.57.0.tgz",
-      "integrity": "sha512-WGc6UL7Hqt+8a6ZAsj/f1ApQl3NPvHY/UQSzG6fB6l4BjExgVdhFaxd7mRTw1UCiYe/6q86zHP+kfvBQcZGvUg=="
+      "version": "5.58.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.58.2.tgz",
+      "integrity": "sha512-K/hOh24cCwRutd1Mk3uLtjWzNISOkm4fvXiMO7LucCrqbh6aJDdtqUziim3MZUI6wOY0rvY1SlL1Ork01uMy6w=="
     },
     "collection-visit": {
       "version": "1.0.0",

--- a/src/common/codemirror_helper.js
+++ b/src/common/codemirror_helper.js
@@ -22,7 +22,7 @@ const addModeScript = (mode, options) => {
 
 const getModeUrl = (mode) => {
   // hardcode for now
-  return `https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.54.0/mode/${mode.mode}/${mode.mode}.min.js`;
+  return `https://cdnjs.cloudflare.com/ajax/libs/codemirror/${CodeMirror.version}/mode/${mode.mode}/${mode.mode}.min.js`;
 };
 
 const fuzzyFindMode = (fuzzy) => {

--- a/src/components/MarkdownEditor.vue
+++ b/src/components/MarkdownEditor.vue
@@ -7,6 +7,7 @@ import { codemirror } from 'vue-codemirror';
 
 // import codemirror dependencies
 import 'codemirror/addon/mode/overlay';
+import 'codemirror/addon/mode/simple';
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/mode/gfm/gfm';
 import 'codemirror/mode/markdown/markdown';


### PR DESCRIPTION
This upgrades CodeMirror to add WebAssembly text format (wast) support for code blocks. This also changes the CDN URL to match the package version.