### PR TITLE
Customize scrollbar for cross OS consistency

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -78,7 +78,7 @@ export default {
   box-sizing: border-box;
   letter-spacing: 0.05em;
   scrollbar-width: thin;
-  scrollbar-color: #666b7a transparent;
+  scrollbar-color: #333 transparent;
 }
 
 *::-webkit-scrollbar {
@@ -88,7 +88,7 @@ export default {
   background: transparent;
 }
 *::-webkit-scrollbar-thumb {
-  background-color: #666b7a;
+  background-color: #333;
   border-radius: 0.125rem;
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -77,6 +77,19 @@ export default {
 * {
   box-sizing: border-box;
   letter-spacing: 0.05em;
+  scrollbar-width: thin;
+  scrollbar-color: #666b7a transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 0.5rem;
+}
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+*::-webkit-scrollbar-thumb {
+  background-color: #666b7a;
+  border-radius: 0.125rem;
 }
 
 body {


### PR DESCRIPTION
Resolves #52 

<img width="1338" alt="image" src="https://user-images.githubusercontent.com/7366727/97586747-fe94f900-19d0-11eb-853e-a52d24e380b2.png">

Currently, the windows version of this scrollbar isn't super consistent
with the theme of octo. Inversely, the OSX version is a bit hard to see
IMO.

To solve this we create a custom scrollbar across OSX/Windows with definitions to support Firefox, Chrome, Edge, etc.

Super open to feedback on the actual design. Threw this together and thought it looked alright on multiple browsers/OS but not tied to any particular setting.