### PR TITLE
Support a vim editor mode

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -268,6 +268,15 @@ svg:not(.close-context) {
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3e%3cpath fill='%231a1a1a' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26l2.974 2.99L8 2.193z'/%3e%3c/svg%3e");
 }
 
+.btn-toggle .custom-radio .custom-control-input ~ .custom-control-label::before {
+  background-color: #999;
+  border-color: #888;
+}
+
+.btn-toggle .custom-radio .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%231a1a1a'/%3e%3c/svg%3e");
+}
+
 .border-transparent {
   border-color: transparent !important;
 }

--- a/src/common/codemirror_helper.js
+++ b/src/common/codemirror_helper.js
@@ -1,21 +1,26 @@
 import CodeMirror from 'codemirror';
 import 'codemirror/mode/meta';
-import 'codemirror/keymap/vim';
 
 let modes = [];
+let vimLoaded = false;
 
 const addModeScript = (mode, options) => {
+  const modeUrl = getModeUrl(mode);
+  
+  addScript(modeUrl, options);
+};
+
+const addScript = (url, { onload, onerror }) => {
   const script = document.createElement('script');
 
-  // pull mode in via CDN
-  script.src = getModeUrl(mode);
+  script.src = url;
 
-  if (options.onload) {
-    script.onload = options.onload;
+  if (onload) {
+    script.onload = onload;
   }
 
-  if (options.onerror) {
-    script.onerror = options.onerror;
+  if (onerror) {
+    script.onerror = onerror;
   }
 
   document.body.appendChild(script);
@@ -57,6 +62,26 @@ export const loadMode = (fuzzyMode, options) => {
   }
 };
 
+export const loadVim = (options) => {
+  // ensure CodeMirror namespace exists in the browser
+  window.CodeMirror = window.CodeMirror || CodeMirror;
+  
+  const vimUrl = `https://cdnjs.cloudflare.com/ajax/libs/codemirror/${CodeMirror.version}/keymap/vim.min.js`;
+  const onload = () => {
+    vimLoaded = true;
+
+    if (options.onload) options.onload();
+  };
+
+  if (!vimLoaded) {
+    addScript(vimUrl, {
+      onload,
+      onerror: options.onerror,
+    });
+  }
+};
+
 export default {
   loadMode,
+  loadVim,
 };

--- a/src/common/codemirror_helper.js
+++ b/src/common/codemirror_helper.js
@@ -1,5 +1,6 @@
 import CodeMirror from 'codemirror';
 import 'codemirror/mode/meta';
+import 'codemirror/keymap/vim';
 
 let modes = [];
 

--- a/src/components/MarkdownEditor.vue
+++ b/src/components/MarkdownEditor.vue
@@ -66,6 +66,7 @@ export default {
             }
           },
         },
+        keyMap: this.settings.keyMap || codemirror.defaults.keyMap,
         indentUnit: this.settings.tabSize || 2,
         indentWithTabs: false,
         lineWrapping: true,

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -4,7 +4,7 @@
       <div class="container-fluid container-xl d-flex">
         <div class="editor d-flex flex-column flex-grow-1" @click="focusEditor">
           <div class="gutter gutter-start" :class="{ 'md-plus': mediumPlus }" @click="focusEditorStart"></div>
-          <MarkdownEditor ref="editable" class="editable" :initialCursor="initialCursor" :settings="settings" :value="document.text" @input="input" @ready="onReady" />
+          <MarkdownEditor ref="editable" class="editable" :initialCursor="initialCursor" :initialVimMode="initialVimMode" :settings="settings" :value="document.text" @input="input" @ready="onReady" />
           <div class="gutter gutter-end flex-grow-1" :class="{ 'md-plus': mediumPlus }" @click="focusEditorEnd"></div>
         </div>
       </div>
@@ -101,6 +101,9 @@ export default {
       validator: (cursor) => (
         cursor.hasOwnProperty('character') && cursor.hasOwnProperty('line')
       ),
+    },
+    initialVimMode: {
+      type: String
     },
   },
   data() {
@@ -209,6 +212,8 @@ export default {
       } else {
         this.$store.dispatch(ADD_DOCUMENT, new Doc({ id: this.document.id, text }));
 
+        console.log('vimMode', this.editor.getOption('keyMap'));
+
         this.$router.push({
           name: 'document',
           params: {
@@ -217,6 +222,7 @@ export default {
               character: this.editor.getCursor().ch,
               line: this.editor.getCursor().line,
             },
+            initialVimMode: this.editor.getOption('keyMap'),
           },
         });
       }

--- a/src/components/TheSettings.vue
+++ b/src/components/TheSettings.vue
@@ -13,13 +13,19 @@
         </div>
         <div class="form-group">
           <label for="config-key-map">Keymaps</label>
-          <div class="form-check">
-            <input class="form-check-input" v-model="keyMap" type="radio" value="default" id="config-key-map-default">
-            <label class="form-check-label" for="config-key-map-default">Default</label>
-          </div>
-          <div class="form-check">
-            <input class="form-check-input" v-model="keyMap" type="radio" value="vim" id="config-key-map-vim">
-            <label class="form-check-label" for="config-key-map-vim">Vim</label>
+          <div>
+            <label class="btn btn-primary btn-toggle">
+              <div class="custom-control custom-radio d-flex align-items-center">
+                <input v-model="keyMap" type="radio" value="default" class="custom-control-input d-flex">
+                <span class="custom-control-label d-flex">Default</span>
+              </div>
+            </label>
+            <label class="btn btn-primary btn-toggle ml-2">
+              <div class="custom-control custom-radio d-flex align-items-center">
+                <input v-model="keyMap" type="radio" value="vim" class="custom-control-input d-flex">
+                <span class="custom-control-label d-flex">Vim</span>
+              </div>
+            </label>
           </div>
           <small class="text-muted">Select an alternate keymapping</small>
         </div>

--- a/src/components/TheSettings.vue
+++ b/src/components/TheSettings.vue
@@ -11,6 +11,18 @@
           <input v-model="tabSize" type="number" min="2" id="config-tab-size" class="form-control">
           <small class="text-muted">Number of spaces per tab (minimum: 2)</small>
         </div>
+        <div class="form-group">
+          <label for="config-key-map">Keymaps</label>
+          <div class="form-check">
+            <input class="form-check-input" v-model="keyMap" type="radio" value="default" id="config-key-map-default">
+            <label class="form-check-label" for="config-key-map-default">Default</label>
+          </div>
+          <div class="form-check">
+            <input class="form-check-input" v-model="keyMap" type="radio" value="vim" id="config-key-map-vim">
+            <label class="form-check-label" for="config-key-map-vim">Vim</label>
+          </div>
+          <small class="text-muted">Select an alternate keymapping</small>
+        </div>
       </section>
       <section>
         <h4 class="font-weight-normal mt-3 mt-md-5">Client-side Encryption</h4>
@@ -66,6 +78,7 @@ import {
   SET_CRYPTO_ENABLED,
   SET_CRYPTO_KEYS,
   SET_EDITOR_TAB_SIZE,
+  SET_EDITOR_KEY_MAP,
 } from '@/store/modules/settings';
 
 export default {
@@ -78,6 +91,14 @@ export default {
   computed: {
     allowCrypto() {
       return this.privateKey && this.publicKey;
+    },
+    keyMap: {
+      get() {
+        return this.$store.state.settings.editor.keyMap;
+      },
+      set(value) {
+        this.$store.dispatch(SET_EDITOR_KEY_MAP, value || 'default');
+      },
     },
     privateKey: {
       get() {

--- a/src/store.js
+++ b/src/store.js
@@ -48,6 +48,7 @@ export default new Vuex.Store({
     },
     online: true,
     showMeta: false,
+    vimLoaded: false,
   },
   getters: {
     allTags(state, getters) {
@@ -101,6 +102,9 @@ export default new Vuex.Store({
     },
     [SET_MOD_KEY] (state, payload) {
       state.modKey = payload;
+    },
+    ['SET_VIM_LOADED'] (state, isVimLoaded) {
+      state.vimLoaded = isVimLoaded;
     },
     [SHOW_MENU] (state) {
       state.menu.show = true;

--- a/src/store/modules/settings.js
+++ b/src/store/modules/settings.js
@@ -1,6 +1,7 @@
 export const LOAD_SETTINGS = 'LOAD_SETTINGS';
 export const SET_CRYPTO_ENABLED = 'SET_CRYPTO_ENABLED';
 export const SET_CRYPTO_KEYS = 'SET_CRYPTO_KEYS';
+export const SET_EDITOR_KEY_MAP = 'SET_EDITOR_KEY_MAP';
 export const SET_EDITOR_TAB_SIZE = 'SET_EDITOR_TAB_SIZE';
 export const SETTINGS_LOADED = 'SETTINGS_LOADED';
 
@@ -13,6 +14,7 @@ export default {
     },
     editor: {
       tabSize: 2,
+      keyMap: 'default',
     },
     loaded: false,
   }),
@@ -36,6 +38,9 @@ export default {
         state.crypto.publicKey = keys.publicKey;
       }
     },
+    [SET_EDITOR_KEY_MAP] (state, keyMap) {
+      state.editor.keyMap = keyMap;
+    },
     [SET_EDITOR_TAB_SIZE] (state, tabSize) {
       state.editor.tabSize = tabSize;
     },
@@ -52,6 +57,9 @@ export default {
     },
     async [SET_CRYPTO_KEYS] (context, keys) {
       context.commit(SET_CRYPTO_KEYS, keys);
+    },
+    async [SET_EDITOR_KEY_MAP] (context, keyMap) {
+      context.commit(SET_EDITOR_KEY_MAP, keyMap);
     },
     async [SET_EDITOR_TAB_SIZE] (context, tabSize) {
       context.commit(SET_EDITOR_TAB_SIZE, tabSize);

--- a/src/store/plugins/caching/settings.js
+++ b/src/store/plugins/caching/settings.js
@@ -4,6 +4,7 @@ import {
   LOAD_SETTINGS,
   SET_CRYPTO_ENABLED,
   SET_CRYPTO_KEYS,
+  SET_EDITOR_KEY_MAP,
   SET_EDITOR_TAB_SIZE,
   SETTINGS_LOADED,
 } from '@/store/modules/settings';
@@ -28,6 +29,7 @@ export default (store) => {
     switch (type) {
       case SET_CRYPTO_ENABLED:
       case SET_CRYPTO_KEYS:
+      case SET_EDITOR_KEY_MAP:
       case SET_EDITOR_TAB_SIZE:
         cache.setItem(CACHE_KEY, state.settings);
 

--- a/src/store/plugins/caching/settings.js
+++ b/src/store/plugins/caching/settings.js
@@ -4,7 +4,6 @@ import {
   LOAD_SETTINGS,
   SET_CRYPTO_ENABLED,
   SET_CRYPTO_KEYS,
-  SET_EDITOR_KEY_MAP,
   SET_EDITOR_TAB_SIZE,
   SETTINGS_LOADED,
 } from '@/store/modules/settings';
@@ -29,7 +28,6 @@ export default (store) => {
     switch (type) {
       case SET_CRYPTO_ENABLED:
       case SET_CRYPTO_KEYS:
-      case SET_EDITOR_KEY_MAP:
       case SET_EDITOR_TAB_SIZE:
         cache.setItem(CACHE_KEY, state.settings);
 


### PR DESCRIPTION
Resolves #60 

<img width="1205" alt="image" src="https://user-images.githubusercontent.com/7366727/97785009-f37ccd00-1b78-11eb-91b0-37c84e9f5203.png">

Take advantage of the CodeMirror keyMap property to support a VIM mode when desired. There's still some improvements to styling that could be made but I think the bones are all there. This approach also makes it easy to add additional modes for emacs and sublime.

One downside is were always pulling in the https://codemirror.net/keymap/vim.js file. We could come up with a solution to lazy load it.

