### PR TITLE
Add Document meta panel

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -271,4 +271,9 @@ svg:not(.close-context) {
 .cursor-pointer {
   cursor: pointer;
 }
+
+.item-divider {
+  background-color: #222;
+  height: 1px;
+}
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -82,14 +82,18 @@ export default {
 }
 
 *::-webkit-scrollbar {
-  width: 0.5rem;
+  width: 0.75rem;
 }
+
 *::-webkit-scrollbar-track {
   background: transparent;
 }
+
 *::-webkit-scrollbar-thumb {
+  background-clip: padding-box;
   background-color: #333;
-  border-radius: 0.125rem;
+  border-radius: 0.25rem;
+  border: 0.125rem solid transparent;
 }
 
 body {

--- a/src/App.vue
+++ b/src/App.vue
@@ -276,4 +276,20 @@ svg:not(.close-context) {
   background-color: #222;
   height: 1px;
 }
+
+.right-3 {
+  right: 1rem !important;
+}
+
+.top-3 {
+  top: 1rem !important;
+}
+
+.z-index-10 {
+  z-index: 10;
+}
+
+.z-index-1 {
+  z-index: 1;
+}
 </style>

--- a/src/components/Context.vue
+++ b/src/components/Context.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container context mt-3 mt-md-5">
+  <div class="container context d-flex flex-column mt-3 mt-md-5">
     <div>
       <h5 class="card-title">Set Context</h5>
       <h6 class="card-subtitle text-muted font-weight-normal mb-3">

--- a/src/components/DiscardableAction.vue
+++ b/src/components/DiscardableAction.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="btn btn-sm btn-secondary destroy" @click.stop="toggle">
+  <button class="btn btn-sm btn-secondary d-flex align-items-center" @click.stop="toggle">
     <DiscardLabel>{{ actionText }}</DiscardLabel>
-  </div>
+  </button>
 </template>
 
 <script>
@@ -34,7 +34,7 @@ export default {
   .destroy {
     align-items: center;
     cursor: pointer;
-    display: flex;
+    /* display: flex; */
   }
 
   .destroy svg {

--- a/src/components/DocumentList.vue
+++ b/src/components/DocumentList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="document-list container-fluid container-xl">
+  <div class="document-list container-fluid container-xl d-flex flex-column">
     <p class="toolbar">
       <TagLabel v-if="tag">{{ tag }}</TagLabel>
       <span v-else class="action">{{ action }}</span>

--- a/src/components/Exporter.vue
+++ b/src/components/Exporter.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="container-lg">
-    <div class="editor">
+  <div class="container-lg d-flex">
+    <div class="editor w-100">
       <MarkdownEditor ref="editable" class="editable" :value="value" />
     </div>
   </div>

--- a/src/components/TagList.vue
+++ b/src/components/TagList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <div class="container d-flex flex-column">
     <Tag class="tag btn btn-secondary" v-for="tag in tags" :key="tag" :tag="tag"></Tag>
   </div>
 </template>

--- a/src/components/TheContent.vue
+++ b/src/components/TheContent.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="the-content-container d-flex flex-grow-1">
     <div class="the-content d-flex flex-grow-1 overflow-auto">
-      <router-view :key="$route.fullPath" class="d-flex flex-column"></router-view>
+      <router-view :key="$route.fullPath" class="d-flex"></router-view>
     </div>
   </div>
 </template>
@@ -19,9 +19,6 @@ export default {
 
 <style>
 .the-content-container {
-  background: url('~@/assets/octopus-transparent.svg') center center no-repeat;
-  background-size: 50% 50%;
-
   /* fix for flex item growing beyond parent size */
   min-width: 0;
 }

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -1,19 +1,43 @@
 <template>
-  <div class="container-fluid container-xl d-flex">
-    <div class="editor d-flex flex-column flex-grow-1" @click="focusEditor">
-      <div class="gutter gutter-start" :class="{ 'md-plus': mediumPlus }" @click="focusEditorStart"></div>
-      <MarkdownEditor ref="editable" class="editable" :initialCursor="initialCursor" :settings="settings" :value="document.text" @input="input" @ready="onReady" />
-      <div class="gutter gutter-end flex-grow-1" :class="{ 'md-plus': mediumPlus }" @click="focusEditorEnd"></div>
-      <div class="document-actions">
-        <DiscardableAction v-if="document.id" :discardedAt="document.discardedAt" :onDiscard="discardDocument" :onRestore="restoreDocument" class="destroy"></DiscardableAction>
-        <button @click.stop="duplicateDocument" class="btn btn-secondary btn-sm d-flex align-items-center">
+  <div class="d-flex flex-grow-1 flex-row">
+    <div class="container-fluid container-xl d-flex">
+      <div class="editor d-flex flex-column flex-grow-1" @click="focusEditor">
+        <div class="gutter gutter-start" :class="{ 'md-plus': mediumPlus }" @click="focusEditorStart"></div>
+        <MarkdownEditor ref="editable" class="editable" :initialCursor="initialCursor" :settings="settings" :value="document.text" @input="input" @ready="onReady" />
+        <div class="gutter gutter-end flex-grow-1" :class="{ 'md-plus': mediumPlus }" @click="focusEditorEnd"></div>
+      </div>
+    </div>
+    <div class="meta p-3">
+      <div class="mb-4">
+        <DiscardableAction v-if="document.id" :discardedAt="document.discardedAt" :onDiscard="discardDocument" :onRestore="restoreDocument" class="w-100 mb-2"></DiscardableAction>
+        <button @click.stop="duplicateDocument" class="btn btn-secondary btn-sm d-flex align-items-center w-100 mb-2">
           <DuplicateLabel>duplicate</DuplicateLabel>
         </button>
-        <button v-if="hasCodeblocks" @click="openSandbox" class="btn btn-secondary btn-sm">
+        <button v-if="hasCodeblocks" @click="openSandbox" class="btn btn-secondary btn-sm d-flex w-100 mb-2">
           <CodeLabel>sandbox</CodeLabel>
         </button>
       </div>
-      <div class="saved-at">{{ savedAt }}</div>
+      <div class="mb-4">
+        <Tag class="item" v-for="tag in document.tags" :key="tag" :tag="tag"></Tag>
+      </div>
+      <div>
+        <div v-if="document.updatedAt" class="mb-1">
+          <small class="text-muted">Last Saved</small>
+          <div>{{ savedAt }}</div>
+        </div>
+        <div v-if="document.createdAt" class="mb-1">
+          <small class="text-muted">Created</small>
+          <div>{{ createdAt }}</div>
+        </div>
+        <div v-if="document.updatedAt" class="mb-1">
+          <small class="text-muted">Updated</small>
+          <div>{{ updatedAt }}</div>
+        </div>
+        <div v-if="document.discardedAt" class="mb-1">
+          <small class="text-muted">Discarded</small>
+          <div>{{ discardedAt }}</div>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -26,6 +50,7 @@ import Doc from '@/models/doc';
 
 import DiscardableAction from '@/components/DiscardableAction';
 import MarkdownEditor from '@/components/MarkdownEditor';
+import Tag from '@/components/Tag';
 
 import {
   ADD_DOCUMENT,
@@ -43,6 +68,7 @@ export default {
     DiscardableAction,
     DuplicateLabel,
     MarkdownEditor,
+    Tag,
   },
   props: {
     initialCursor: {
@@ -86,14 +112,23 @@ export default {
     savedAt() {
       if (this.$route.params.id) {
         if (this.now.diff(this.document.updatedAt, 'seconds') < 5) {
-          return 'Saved just now';
+          return 'just now';
         }
         else {
-          return `Saved ${moment(this.document.updatedAt).from(this.now, true)} ago`;
+          return `${moment(this.document.updatedAt).from(this.now, true)} ago`;
         }
       }
 
       return 'Not yet saved';
+    },
+    createdAt() {
+      return moment(this.document.createdAt).format('ddd, MMM Do, YYYY [at] h:mm A');
+    },
+    discardedAt() {
+      return moment(this.document.discardedAt).format('ddd, MMM Do, YYYY [at] h:mm A');
+    },
+    updatedAt() {
+      return moment(this.document.updatedAt).format('ddd, MMM Do, YYYY [at] h:mm A');
     },
   },
   methods: {
@@ -172,21 +207,14 @@ export default {
 </script>
 
 <style scoped>
+  .editor {
+    background: url('~@/assets/octopus-transparent.svg') center center no-repeat;
+    background-size: 50% 50%;
+  }
+
   .editor .editable {
     outline: none;
     white-space: pre-wrap;
-  }
-
-  .editor .saved-at {
-    bottom: 0;
-    color: #aaa;
-    margin: 1rem;
-    position: fixed;
-    right: 0;
-  }
-
-  .editor .tag {
-    padding: 0.25em 1em;
   }
 
   .editor .gutter {
@@ -195,16 +223,8 @@ export default {
     width: 100%;
   }
 
-  .document-actions {
-    color: #aaa;
-    position: fixed;
-    margin-right: 1rem;
-    margin-top: 1rem;
-    right: 0;
-    z-index: 10;
-  }
-
-  .document-actions > *:not(:first-child) {
-    margin-top: 0.5rem;
+  .meta {
+    background-color: #050505;
+    min-width: 17rem;
   }
 </style>

--- a/src/components/TheSidebar.vue
+++ b/src/components/TheSidebar.vue
@@ -24,7 +24,7 @@
               <ModK/>
             </span>
           </h6>
-          <div class="item-divider"></div>
+          <div class="item-divider mx-3 mb-2"></div>
           <router-link class="item px-3 py-2 py-md-1 d-flex align-items-center" :to="{ name: 'dashboard' }">
             <svg class="bi bi-file-earmark-plus" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
               <path d="M9 1H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h5v-1H4a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1h5v2.5A1.5 1.5 0 0 0 10.5 6H13v2h1V6L9 1z"/>
@@ -74,7 +74,7 @@
               <ModK/>
             </span>
           </h6>
-          <div class="item-divider"></div>
+          <div class="item-divider mx-3 mb-2"></div>
           <router-link class="item px-3 py-2 py-md-1 d-flex" :to="{ name: 'actionable' }">
             <TaskLabel class="flex-grow-1">
               <span class="d-flex align-items-center justify-content-between">
@@ -112,7 +112,7 @@
           <h6 class="dropdown-header mx-0 mt-3 px-3 d-flex justify-content-between">
             <span>tags</span>
           </h6>
-          <div class="item-divider"></div>
+          <div class="item-divider mx-3 mb-2"></div>
           <Tag class="item px-3 py-2 py-md-1" v-for="tag in tags" :key="tag" :tag="tag"></Tag>
         </div>
       </div>
@@ -179,12 +179,6 @@ export default {
 
 .side-nav .item:first-child {
   margin-top: -0.25rem;
-}
-
-.side-nav .item-divider {
-  background-color: #222;
-  height: 1px;
-  margin: 0 1rem 0.5rem 1rem;
 }
 
 .keybinding {

--- a/src/components/icons/Info.vue
+++ b/src/components/icons/Info.vue
@@ -1,0 +1,21 @@
+<template>
+  <BaseSvg :size="size">
+    <path fill-rule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+    <path d="M8.93 6.588l-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588z"/>
+    <circle cx="8" cy="4.5" r="1"/>
+  </BaseSvg>
+</template>
+
+<script>
+import BaseSvg from '@/components/icons/BaseSvg';
+
+export default {
+  name: 'Info',
+  props: {
+    size: String,
+  },
+  components: {
+    BaseSvg,
+  },
+};
+</script>

--- a/src/components/labels/Info.vue
+++ b/src/components/labels/Info.vue
@@ -1,0 +1,24 @@
+<template>
+  <Base>
+    <InfoIcon :size="iconSize" />
+    <div class="flex-grow-1">
+      <slot></slot>
+    </div>
+  </Base>
+</template>
+
+<script>
+import Base from '@/components/labels/Base';
+import InfoIcon from '@/components/icons/Info';
+
+export default {
+  name: 'Info',
+  props: {
+    iconSize: String,
+  },
+  components: {
+    Base,
+    InfoIcon,
+  },
+};
+</script>

--- a/src/store.js
+++ b/src/store.js
@@ -29,6 +29,7 @@ import {
   SET_OFFLINE,
   SET_ONLINE,
   SHOW_MENU,
+  TOGGLE_META,
 } from '@/store/actions';
 
 Vue.use(Vuex);
@@ -46,6 +47,7 @@ export default new Vuex.Store({
       show: false,
     },
     online: true,
+    showMeta: false,
   },
   getters: {
     allTags(state, getters) {
@@ -103,6 +105,9 @@ export default new Vuex.Store({
     [SHOW_MENU] (state) {
       state.menu.show = true;
     },
+    [TOGGLE_META] (state) {
+      state.showMeta = !state.showMeta;
+    },
   },
   actions: {
     async [ACTIVATE_CONTEXT] (context) {
@@ -152,6 +157,9 @@ export default new Vuex.Store({
     },
     async [SHOW_MENU] (context) {
       context.commit(SHOW_MENU);
+    },
+    async [TOGGLE_META] (context) {
+      context.commit(TOGGLE_META);
     },
   },
   modules: {

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -18,6 +18,7 @@ export const SET_MOD_KEY = 'SET_MOD_KEY';
 export const SET_OFFLINE = 'SET_OFFLINE';
 export const SET_ONLINE = 'SET_ONLINE';
 export const SHOW_MENU = 'SHOW_MENU';
+export const TOGGLE_META = 'TOGGLE_META';
 export const TOUCH_DOCUMENT = 'TOUCH_DOCUMENT';
 
 export default {
@@ -41,5 +42,6 @@ export default {
   SET_OFFLINE,
   SET_ONLINE,
   SHOW_MENU,
+  TOGGLE_META,
   TOUCH_DOCUMENT,
 };


### PR DESCRIPTION
- closes #65 

### Summary

This moves the existing actions into a new "meta" panel that can be toggled from the editor view. The new meta panel also shows tags in the active document and the document's relevant timestamps.