### PR TITLE
Render images from markdown image tags

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -183,6 +183,10 @@ a, a:hover {
   border-color: #888;
 }
 
+.btn-toggle .custom-checkbox .custom-control-input:disabled:checked ~ .custom-control-label::before {
+  background-color: #444;
+}
+
 .btn-toggle .custom-checkbox .custom-control-input:checked ~ .custom-control-label::after {
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3e%3cpath fill='%231a1a1a' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26l2.974 2.99L8 2.193z'/%3e%3c/svg%3e");
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -200,6 +200,10 @@ a, a:hover {
   font-family: 'Fira Mono', monospace !important;
 }
 
+.sans-serif {
+  font-family: 'Fira Sans', arial !important;
+}
+
 .card {
   background-color: #1a1a1a;
   margin-bottom: 1em;

--- a/src/common/code_sandbox.js
+++ b/src/common/code_sandbox.js
@@ -1,5 +1,4 @@
 export const create = (files) => {
-  console.log('files', files);
   const options = {
     method: 'POST',
     headers: {

--- a/src/common/markdown/markdown.js
+++ b/src/common/markdown/markdown.js
@@ -1,0 +1,22 @@
+import { parseCodeblocks } from '@/common/parsers'
+import { extractImages, stripCodeblocks } from './utils'
+
+class Markdown {
+  constructor(text) {
+    this.text = text || ''
+  }
+
+  codeblocks() {
+    return parseCodeblocks(this.text)
+  }
+
+  images() {
+    return extractImages(this.text)
+  }
+
+  stripCodeblocks() {
+    return stripCodeblocks(this.text)
+  }
+}
+
+export default Markdown

--- a/src/common/markdown/utils.js
+++ b/src/common/markdown/utils.js
@@ -1,0 +1,60 @@
+import { parseImages } from '@/common/parsers'
+
+const multilineTokens = ['````', '```']
+const inlineTokens = ['``', '`']
+
+export const extractImages = (text) => {
+  let images = []
+
+  stripCodeblocks(text).split('\n').forEach((line, index) => {
+    const matches = parseImages(line)
+
+    images.push(
+      ...matches.map((match) => ({
+        alt: match.alt || null,
+        line: index,
+        url: match.url,
+      }))
+    )
+  })
+
+  return images
+}
+
+export const stripCodeblocks = (text) => {
+  return stripInlineCodeblocks(
+    // multiline codeblocks need to be stripped first
+    stripMultilineCodeblocks(text)
+  )
+}
+
+export const stripInlineCodeblocks = (text) => {
+  let final = text
+
+  inlineTokens.forEach((token) => {
+    const searchRegex = new RegExp(`${token}.*?${token}`, 'g')
+
+    final = final.replace(searchRegex, '')
+  })
+
+  return final
+}
+
+export const stripMultilineCodeblocks = (text) => {
+  let final = text
+
+  multilineTokens.forEach((token) => {
+    const searchRegex = new RegExp(`${token}.*?${token}`, 'gs')
+
+    final = final.replace(searchRegex, (match) => match.replace(/[^\n]*/g, ''))
+  })
+
+  return final
+}
+
+export default {
+  extractImages,
+  stripCodeblocks,
+  stripInlineCodeblocks,
+  stripMultilineCodeblocks,
+}

--- a/src/common/parsers.js
+++ b/src/common/parsers.js
@@ -1,4 +1,5 @@
 const codeRegex = /```([^\n\s]*)(?:\s([\w-]+\.[\w]+))?\n(.*?)```/gs;
+const imageTagRegex = /\!\[(.*?)\]\((.+?)\)/g;
 const tagsRegex = /````.*?````|```.*?```|``.*?``|`.*?`|\w+:\/?\/?\S*|#([\w-]+)/gs;
 const tasksRegex = /````.*?````|```.*?```|``.*?``|`.*?`|\-\ \[\ \] ([^\n]+)/gs;
 
@@ -23,6 +24,22 @@ export const parseCodeblocks = (text) => {
       language: match[1],
       code: match[3],
     });
+  });
+
+  return results;
+};
+
+export const parseImages = (text) => {
+  let matches = parse(imageTagRegex, text);
+  let results = [];
+
+  matches.forEach((match) => {
+    if (match[2]) {
+      results.push({
+        alt: match[1],
+        url: match[2],
+      });
+    }
   });
 
   return results;
@@ -57,5 +74,6 @@ export const parseTasks = (text) => {
 export default {
   parse,
   parseCodeblocks,
+  parseImages,
   parseTags,
 };

--- a/src/components/MarkdownEditor.vue
+++ b/src/components/MarkdownEditor.vue
@@ -229,6 +229,10 @@ export default {
   color: #9e9e9e;
 }
 
+.CodeMirror.cm-s-yeti .cm-formatting-em, .CodeMirror.cm-s-yeti .cm-formatting-strong, .CodeMirror.cm-s-yeti .cm-formatting-strikethrough {
+  color: #444;
+}
+
 .CodeMirror.CodeMirror-focused.cm-s-yeti .CodeMirror-selected, .CodeMirror.cm-s-yeti .CodeMirror-selected {
   background: #555;
 }

--- a/src/components/MarkdownEditor.vue
+++ b/src/components/MarkdownEditor.vue
@@ -123,22 +123,25 @@ export default {
       // TODO: only clear the ones that change
       this.widgets.forEach(widget => this.editor.removeLineWidget(widget))
 
-      this.images.forEach((image) => {
-        let lineWidget
+      if (this.settings.images.enabled) {
+        this.images.forEach((image) => {
+          let lineWidget
 
-        const component = new ImageInstance({
-          propsData: {
-            alt: image.alt,
-            onError: () => lineWidget.changed(),
-            onLoad: () => lineWidget.changed(),
-            source: image.url,
-          },
+          const component = new ImageInstance({
+            propsData: {
+              alt: image.alt,
+              onError: () => lineWidget.changed(),
+              onLoad: () => lineWidget.changed(),
+              showCaptions: this.settings.images.showCaptions,
+              source: image.url,
+            },
+          })
+
+          lineWidget = this.editor.addLineWidget(image.line, component.$mount().$el, { above: true })
+
+          this.widgets.push(lineWidget)
         })
-
-        lineWidget = this.editor.addLineWidget(image.line, component.$mount().$el, { above: true })
-
-        this.widgets.push(lineWidget)
-      })
+      }
     },
     loadModes() {
       this.codeblocks.forEach((codeblock) => {

--- a/src/components/MarkdownEditorImage.vue
+++ b/src/components/MarkdownEditorImage.vue
@@ -2,7 +2,7 @@
   <div class="container rounded d-flex align-items-center justify-content-center p-3 mw-100 mb-2">
     <figure class="m-0">
       <img :src="source" @load="onLoad" @error="onError" :alt="alt" class="mw-100">
-      <figcaption v-if="alt" class="sans-serif text-center mt-3"><small>{{ alt }}</small></figcaption>
+      <figcaption v-if="showCaptions && alt" class="sans-serif text-center mt-3"><small>{{ alt }}</small></figcaption>
     </figure>
   </div>
 </template>
@@ -14,6 +14,7 @@ export default {
     alt: String,
     onError: Function,
     onLoad: Function,
+    showCaptions: Boolean,
     source: String,
   },
 };

--- a/src/components/MarkdownEditorImage.vue
+++ b/src/components/MarkdownEditorImage.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="container rounded d-flex align-items-center justify-content-center p-3 mw-100 mb-2">
+    <figure class="m-0">
+      <img :src="source" @load="onLoad" @error="onError" :alt="alt" class="mw-100">
+      <figcaption v-if="alt" class="sans-serif text-center mt-3"><small>{{ alt }}</small></figcaption>
+    </figure>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'MarkdownEditorImage',
+  props: {
+    alt: String,
+    onError: Function,
+    onLoad: Function,
+    source: String,
+  },
+};
+</script>
+
+<style scoped>
+.container {
+  background-color: rgba(0, 0, 0, 0.3)
+}
+
+.container img {
+  max-height: 20rem;
+}
+</style>

--- a/src/components/TheSettings.vue
+++ b/src/components/TheSettings.vue
@@ -29,6 +29,29 @@
           </div>
           <small class="text-muted">Select an alternate keymapping</small>
         </div>
+        <div class="form-group">
+          <h5 class="font-weight-normal">Images</h5>
+          <div class="form-group">
+            <p>This setting determines whether or not image tags (e.g. <code class="text-muted">![alt text](/path/to/image)</code>) will render images in your documents.</p>
+          </div>
+          <div class="form-group">
+            <div>
+              <label class="btn btn-primary btn-toggle">
+                <div class="custom-control custom-checkbox d-flex align-items-center">
+                  <input v-model="imagesEnabled" type="checkbox" class="custom-control-input d-flex">
+                  <span class="custom-control-label d-flex">Enable Images</span>
+                </div>
+              </label>
+              <label class="btn btn-primary btn-toggle ml-2">
+                <div class="custom-control custom-checkbox d-flex align-items-center">
+                  <input v-model="showCaptions" :disabled="!imagesEnabled" type="checkbox" class="custom-control-input d-flex">
+                  <span class="custom-control-label d-flex">Show Captions</span>
+                </div>
+              </label>
+            </div>
+            <small class="text-muted">Note: Captions are pulled from alt text and rendered under your images in the image container.</small>
+          </div>
+        </div>
       </section>
       <section>
         <h4 class="font-weight-normal mt-3 mt-md-5">Client-side Encryption</h4>
@@ -83,6 +106,8 @@ import { TOUCH_DOCUMENT } from '@/store/actions';
 import {
   SET_CRYPTO_ENABLED,
   SET_CRYPTO_KEYS,
+  SET_EDITOR_IMAGES_ENABLED,
+  SET_EDITOR_IMAGES_SHOW_CAPTIONS,
   SET_EDITOR_TAB_SIZE,
   SET_EDITOR_KEY_MAP,
 } from '@/store/modules/settings';
@@ -97,6 +122,14 @@ export default {
   computed: {
     allowCrypto() {
       return this.privateKey && this.publicKey;
+    },
+    imagesEnabled: {
+      get() {
+        return this.$store.state.settings.editor.images.enabled;
+      },
+      set(value) {
+        this.$store.dispatch(SET_EDITOR_IMAGES_ENABLED, value);
+      },
     },
     keyMap: {
       get() {
@@ -124,6 +157,14 @@ export default {
         this.$store.dispatch(SET_CRYPTO_KEYS, {
           publicKey: value,
         });
+      },
+    },
+    showCaptions: {
+      get() {
+        return this.$store.state.settings.editor.images.showCaptions;
+      },
+      set(value) {
+        this.$store.dispatch(SET_EDITOR_IMAGES_SHOW_CAPTIONS, value);
       },
     },
     tabSize: {

--- a/src/store/modules/settings.js
+++ b/src/store/modules/settings.js
@@ -3,6 +3,8 @@ import deepmerge from 'deepmerge';
 export const LOAD_SETTINGS = 'LOAD_SETTINGS';
 export const SET_CRYPTO_ENABLED = 'SET_CRYPTO_ENABLED';
 export const SET_CRYPTO_KEYS = 'SET_CRYPTO_KEYS';
+export const SET_EDITOR_IMAGES_ENABLED = 'SET_EDITOR_IMAGES_ENABLED';
+export const SET_EDITOR_IMAGES_SHOW_CAPTIONS = 'SET_EDITOR_IMAGES_SHOW_CAPTIONS';
 export const SET_EDITOR_KEY_MAP = 'SET_EDITOR_KEY_MAP';
 export const SET_EDITOR_TAB_SIZE = 'SET_EDITOR_TAB_SIZE';
 export const SETTINGS_LOADED = 'SETTINGS_LOADED';
@@ -15,8 +17,12 @@ export default {
       publicKey: null,
     },
     editor: {
-      tabSize: 2,
+      images: {
+        enabled: true,
+        showCaptions: true,
+      },
       keyMap: 'default',
+      tabSize: 2,
     },
     loaded: false,
   }),
@@ -39,6 +45,12 @@ export default {
         state.crypto.publicKey = keys.publicKey;
       }
     },
+    [SET_EDITOR_IMAGES_ENABLED] (state, isEnabled) {
+      state.editor.images.enabled = isEnabled;
+    },
+    [SET_EDITOR_IMAGES_SHOW_CAPTIONS] (state, showCaptions) {
+      state.editor.images.showCaptions = showCaptions;
+    },
     [SET_EDITOR_KEY_MAP] (state, keyMap) {
       state.editor.keyMap = keyMap;
     },
@@ -58,6 +70,12 @@ export default {
     },
     async [SET_CRYPTO_KEYS] (context, keys) {
       context.commit(SET_CRYPTO_KEYS, keys);
+    },
+    async [SET_EDITOR_IMAGES_ENABLED] (context, isEnabled) {
+      context.commit(SET_EDITOR_IMAGES_ENABLED, isEnabled);
+    },
+    async [SET_EDITOR_IMAGES_SHOW_CAPTIONS] (context, showCaptions) {
+      context.commit(SET_EDITOR_IMAGES_SHOW_CAPTIONS, showCaptions);
     },
     async [SET_EDITOR_KEY_MAP] (context, keyMap) {
       context.commit(SET_EDITOR_KEY_MAP, keyMap);

--- a/src/store/plugins/caching/settings.js
+++ b/src/store/plugins/caching/settings.js
@@ -4,6 +4,8 @@ import {
   LOAD_SETTINGS,
   SET_CRYPTO_ENABLED,
   SET_CRYPTO_KEYS,
+  SET_EDITOR_IMAGES_ENABLED,
+  SET_EDITOR_IMAGES_SHOW_CAPTIONS,
   SET_EDITOR_KEY_MAP,
   SET_EDITOR_TAB_SIZE,
   SETTINGS_LOADED,
@@ -29,6 +31,8 @@ export default (store) => {
     switch (type) {
       case SET_CRYPTO_ENABLED:
       case SET_CRYPTO_KEYS:
+      case SET_EDITOR_IMAGES_ENABLED:
+      case SET_EDITOR_IMAGES_SHOW_CAPTIONS:
       case SET_EDITOR_KEY_MAP:
       case SET_EDITOR_TAB_SIZE:
         cache.setItem(CACHE_KEY, state.settings);


### PR DESCRIPTION
- closes #79 

### Summary

CodeMirror line widgets allow us to inject elements either above or below lines in the editor. Using this feature, we can scan the document for image tags (ignoring code) and build the elements to inject into the document. This feature has two corresponding settings: Images Enabled (to toggle the entire feature) and Show Captions (to toggle just the captions).