### PR TITLE
Fix scrolling in Safari (and other iOS browsers)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="h-100">
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -12,12 +12,24 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootswatch/4.5.0/darkly/bootstrap.min.css" integrity="sha384-Bo21yfmmZuXwcN/9vKrA5jPUMhr7znVBBeLxT9MA4r2BchhusfJ6+n8TLGUcRAtL" crossorigin="anonymous">
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.26.0/moment.min.js" integrity="sha256-5oApc/wMda1ntIEK4qoWJ4YItnV4fBHMwywunj8gPqc=" crossorigin="anonymous"></script>
+
+    <style>
+      html {
+        height: -webkit-fill-available;
+      }
+
+      body, #app {
+        height: 100vh;
+        height: -webkit-fill-available;
+      }
+    </style>
   </head>
-  <body class="h-100">
+  <body class="d-flex flex-column">
     <noscript>
       <strong>Octo does not work without JavaScript. Please enable it to continue.</strong>
     </noscript>
-    <div id="app" class="h-100"></div>
+    <!-- #app is replaced by App.vue -->
+    <div id="app"></div>
     <!-- built files will be auto injected -->
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=0">
 
     <title>octo</title>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app" class="d-flex flex-column h-100" :class="sizes">
+  <div id="app" class="d-flex flex-column flex-grow-1 flex-shrink-1" :class="sizes">
     <simplebar v-if="context.active || context.editing" class="context-banner relative-fixed">
       <div class="d-flex align-items-center text-center">
         <div v-if="contextTags.length" class="context-tags">
@@ -13,8 +13,8 @@
         </div>
       </div>
     </simplebar>
-    <div class="flex-grow-1 position-relative overflow-hidden">
-      <router-view class="d-flex h-100"></router-view>
+    <div class="d-flex flex-column flex-grow-1 flex-shrink-1 position-relative min-h-0">
+      <router-view class="flex-grow-1 flex-shrink-1 min-h-0"></router-view>
       <div class="card notification position-fixed top-0 right-0 m-3 m-md-2" :class="{ 'd-none': !showModal }">
         <div class="card-body notification-body">
           <p>An update is available. Refresh the app to apply.</p>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -1,8 +1,12 @@
 <template>
-  <div class="d-flex align-items-stretch">
-    <TheLeftSidebar v-if="!mobile && showLeftSidebar" class="sidebar d-none d-md-flex bg-darker" />
-    <TheContent class="flex-grow-1" />
-    <TheRightSidebar v-if="!mobile && showRightSidebar && currentDoc" class="sidebar d-none d-md-flex bg-darker" />
+  <div class="d-flex flex-column">
+    <div class="d-flex flex-grow-1 flex-shrink-1 min-h-0">
+      <TheLeftSidebar v-if="!mobile && showLeftSidebar" class="sidebar d-none d-md-flex bg-darker" />
+      <div class="d-flex flex-column flex-grow-1 flex-shrink-1 min-h-0">
+        <TheContent class="flex-grow-1 flex-shrink-1 min-h-0" />
+      </div>
+      <TheRightSidebar v-if="!mobile && showRightSidebar && currentDoc" class="sidebar d-none d-md-flex bg-darker" />
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
- closes #87 

### Summary

Scrolling was completely broken on iOS (and in Safari on desktop). This was apparently due to a number of conflating factors including the `overflow-hidden` class at the top level in `App.vue`, the use of `h-100`, and `d-flex`. This caused the content to be clipped and therefore not scrollable. The solution was to migrate to using flex (`d-flex`, `flex-column`, `flex-grow-1`, `flex-shrink-1`) to manage containers of vertical content.

Note: All browsers on iOS use Safari web views, so this was likely broken in all browsers on iOS.